### PR TITLE
Fix | Add `apply` subcommand to documentation

### DIFF
--- a/docs/user-guide/base-workflow/leverage-cli/reference/terraform.md
+++ b/docs/user-guide/base-workflow/leverage-cli/reference/terraform.md
@@ -35,6 +35,20 @@ All arguments given are passed as received to Terraform.
 Can only be run at **layer** level.
 
 ---
+## `apply`
+
+### Usage
+``` bash
+leverage terraform apply [arguments]
+```
+
+Equivalent to `terraform apply`.
+
+All arguments given are passed as received to Terraform.
+
+Can only be run at **layer** level.
+
+---
 ## `destroy`
 
 ### Usage
@@ -60,7 +74,7 @@ Equivalent to `terraform output`.
 
 All arguments given are passed as received to Terraform.
 
-Can only be run at **layer** level. Doesn't require MFA.
+Can only be run at **layer** level.
 
 ---
 ## `version`


### PR DESCRIPTION
## What
* Add missing documentation for `apply` subcommand of the `terraform` command

## References
* closes #91 
