### PR TITLE
Feature/remove cards solved issue

### DIFF
--- a/docs/first-steps/management-account.md
+++ b/docs/first-steps/management-account.md
@@ -29,16 +29,6 @@ leverage terraform apply
 All `apply` commands will prompt for confirmation, answer `yes` when this happens.
 
 !!! info "More information on [`terraform init`](../../user-guide/base-workflow/leverage-cli/reference/terraform#init) and [`terraform apply`](../../user-guide/base-workflow/leverage-cli/reference/terraform#apply)"
-!!! note
-    The `apply` command may result in an error similar to:
-
-    ```
-    Error: error creating public access block policy for S3 bucket (me-security-terraform-backend): 
-    OperationAborted: A conflicting conditional operation is currently in progress against this resource. 
-    Please try again.
-    ```
-
-    If this happens, please re-run the command.
 
 Now, the infrastructure for the Terraform state management is created. The next step is to push the local `.tfstate` to the bucket. To do this, uncomment the `backend` section for the `terraform` configuration in `management/base-tf-backend/config.tf`
 

--- a/docs/first-steps/security-and-shared-accounts.md
+++ b/docs/first-steps/security-and-shared-accounts.md
@@ -21,17 +21,6 @@ leverage terraform init
 leverage terraform apply
 ```
 
-!!! note
-    The `apply` command may result in an error similar to:
-
-    ```
-    Error: error creating public access block policy for S3 bucket (me-security-terraform-backend): 
-    OperationAborted: A conflicting conditional operation is currently in progress against this resource. 
-    Please try again.
-    ```
-
-    If this happens, please re-run the command.
-
 Now, to push the local `.tfstate` to the bucket, uncomment the `backend` section for the `terraform` configuration in `security/base-tf-backend/config.tf`
 
 ``` terraform
@@ -99,17 +88,6 @@ Move into the `us-east-1/base-tf-backend` directory and run:
 leverage terraform init
 leverage terraform apply
 ```
-
-!!! note
-    The `apply` command may result in an error similar to:
-
-    ```
-    Error: error creating public access block policy for S3 bucket (me-security-terraform-backend): 
-    OperationAborted: A conflicting conditional operation is currently in progress against this resource. 
-    Please try again.
-    ```
-
-    If this happens, please re-run the command.
 
 Now, to push the local `.tfstate` to the bucket, uncomment the `backend` section for the `terraform` configuration in `shared/base-tf-backend/config.tf`
 


### PR DESCRIPTION
## What?
Remove cards from First-Steps guide for already resolved Terraform Backend module issue upon deploying from:
- first-steps/security-and-shared-accounts  (1 ocurrence)
- first-steps/management-account (2 ocurrences)

## Why?
- The workaround is no longer necessary

## References
#114 

