### PR TITLE
added example for terraform commands in the shell

### DIFF
--- a/docs/user-guide/leverage-cli/reference/terraform.md
+++ b/docs/user-guide/leverage-cli/reference/terraform.md
@@ -109,14 +109,10 @@ Open a shell into the Terraform container in the current directory. An authentic
 _Note:_ When `--sso` flag is used, the `--mfa` flag status is ignored.
 
 !!! example "What if I want to run a Terraform command that is not supported by the CLI?"
-
-
     One common error you could encounter is `"Error acquiring the state lock"`, where you might need to use `force-unlock`. You can do the following:
 
-    1 - `leverage terraform shell --sso` 
-
-    2 - Then from inside the container: `terraform force-unlock LOCK-ID`
-
+    1. `leverage terraform shell --sso`.       
+    2.  Then from inside the container: `terraform force-unlock LOCK-ID`.
 
 ---
 ## `format`

--- a/docs/user-guide/leverage-cli/reference/terraform.md
+++ b/docs/user-guide/leverage-cli/reference/terraform.md
@@ -108,6 +108,15 @@ Open a shell into the Terraform container in the current directory. An authentic
 
 _Note:_ When `--sso` flag is used, the `--mfa` flag status is ignored.
 
+!!! example "What if I want to run a Terraform command that is not supported by the CLI?"
+
+
+    One common error you could encounter is `"Error acquiring the state lock"`, where you might need to use `force-unlock`. You can do the following:
+
+    1 - `leverage terraform shell --sso` 
+
+    2 - Then from inside the container: `terraform force-unlock LOCK-ID`
+
 
 ---
 ## `format`

--- a/docs/user-guide/ref-architecture-ansible/workflow.md
+++ b/docs/user-guide/ref-architecture-ansible/workflow.md
@@ -13,4 +13,7 @@
     4. Make whatever changes you need to make as stated in each Playbook Documentation (check Documentation section above)
     5. For a dry run execution use `leverage run apply\[--check\]` if you only mean to preview those changes
     6. Run `leverage run apply` if you want to apply those changes
-    7. Run `leverage run apply\["--tags","common"\]` if you want to target specific playbook tasks by tag (eg: common tag) 
+    7. If you want to target specific playbook tasks by tag (eg: common tag) you can run one of the following options:        
+        Opt-1:  `leverage run apply["--tags","common"]`     
+        Opt-2:  `noglob leverage run apply["--tags","common"]`      
+        Opt-3:  `leverage shell` and then `ansible-playbook setup.yml --tags common`  


### PR DESCRIPTION
## What?
* Added an example box for running TF commands inside shell

## Why?
* Doc was not clear enough for specific use cases (running a TF command not supported by the CLI)
* Adding a specific example of a common issue where we need to use a TF command inside the shell

## References
* There are many TF [commands](https://www.terraform.io/cli/commands) not supported by the CLI (as they are not used on a daily basis). The one used in the example is [force-unlock](https://www.terraform.io/cli/commands/force-unlock).

