### PR TITLE
ISSUE-125 | add --skip-validation flag to documentation

### DIFF
--- a/docs/first-steps/management-account.md
+++ b/docs/first-steps/management-account.md
@@ -22,7 +22,7 @@ cd management
 Move into the `us-east-1/base-tf-backend` directory and run:
 
 ``` bash
-leverage terraform init
+leverage terraform init --skip-validation
 leverage terraform apply
 ```
 

--- a/docs/first-steps/security-and-shared-accounts.md
+++ b/docs/first-steps/security-and-shared-accounts.md
@@ -85,7 +85,7 @@ cd shared
 Move into the `us-east-1/base-tf-backend` directory and run:
 
 ``` bash
-leverage terraform init
+leverage terraform init --skip-validation
 leverage terraform apply
 ```
 

--- a/docs/first-steps/security-and-shared-accounts.md
+++ b/docs/first-steps/security-and-shared-accounts.md
@@ -17,7 +17,7 @@ cd security
 Move into the `us-east-1/base-tf-backend` directory and run:
 
 ``` bash
-leverage terraform init
+leverage terraform init --skip-validation
 leverage terraform apply
 ```
 

--- a/docs/user-guide/ref-architecture-aws/tf-state-workflow.md
+++ b/docs/user-guide/ref-architecture-aws/tf-state-workflow.md
@@ -35,7 +35,7 @@ Terraform modules registry, accessed December 3rd 2020).
 !!! example "Steps to initialize your tf-backend"
     1. At the corresponding account dir, 
       eg: [/shared/base-tf-backend](https://github.com/binbashar/le-tf-infra-aws/tree/master/shared/us-east-1/base-tf-backend) then,
-    2. Run `leverage terraform init`
+    2. Run `leverage terraform init --skip-validation`
     3. Run `leverage terraform plan`, review the output to understand the expected changes
     4. Run `leverage terraform apply`, review the output once more and type `yes` if you are okay with that
     5. This should create a `terraform.tfstate` file in this directory but we don't want to push that to the repository so 


### PR DESCRIPTION
Added --skip-validation to <leverage terraform init> lines in documentation when there is no S3 set yet.

## What?
* Description on whether to add this flag added to these files:
  * docs/first-steps/management-account.md
  * docs/first-steps/security-and-shared-accounts.md
  * docs/user-guide/ref-architecture-aws/tf-state-workflow.md

## Why?
* When `leverage terraform init` is run for the very first time, there is no S3 bucket created to be set as a backend. The command as it is will fail.
* The flag `--skip-validation` allows to run the command, creating the bucket.
* After it is created, the backend can be set and the `init` command can be run with no errors.
* Close #125 

## References
* URLs belonging to modified files:
  * https://leverage.binbash.com.ar/first-steps/management-account/#terraform-backend-layer
  * https://leverage.binbash.com.ar/first-steps/security-and-shared-accounts/#terraform-backend-layer
  * https://leverage.binbash.com.ar/user-guide/ref-architecture-aws/tf-state-workflow/#set-up

