### PR TITLE
Kubectl command documentation

### DIFF
--- a/docs/user-guide/leverage-cli/install-leverage-cli.md
+++ b/docs/user-guide/leverage-cli/install-leverage-cli.md
@@ -72,6 +72,7 @@ Options:
 Commands:
   aws          Run AWS CLI commands in a custom containerized environment.
   credentials  Manage AWS cli credentials.
+  kubectl      Run Kubectl commands in a custom containerized environment.
   project      Manage a Leverage project.
   run          Perform specified task(s) and all of its dependencies.
   terraform    Run Terraform commands in a custom containerized...

--- a/docs/user-guide/leverage-cli/reference/basic-features.md
+++ b/docs/user-guide/leverage-cli/reference/basic-features.md
@@ -18,6 +18,7 @@ Options:
 Commands:
   aws          Run AWS CLI commands in a custom containerized environment.
   credentials  Manage AWS cli credentials.
+  kubectl      Run Kubectl commands in a custom containerized environment.
   project      Manage a Leverage project.
   run          Perform specified task(s) and all of its dependencies.
   terraform    Run Terraform commands in a custom containerized...

--- a/docs/user-guide/leverage-cli/reference/kubectl.md
+++ b/docs/user-guide/leverage-cli/reference/kubectl.md
@@ -1,14 +1,14 @@
 # Command: `kubectl`
 
 !!! info "Regarding Leverage Toolbox versions"
-    For using this feature Leverage Toolbox versions `1.2.7-0.1.7` and up, or `1.3.5-0.1.7` and up must be used.
+    To have this feature available, Leverage Toolbox versions `1.2.7-0.1.7` and up, or `1.3.5-0.1.7` and up must be used.
 
 The `kubectl` command is a wrapper for a containerized installation of [kubectl](https://kubernetes.io/docs/reference/kubectl/). It provides the kubectl executable with specific configuration values required by Leverage.
 
 It transparently handles authentication, whether it is Multi-Factor or via Single Sign-On, on behalf of the user in the commands that require it. SSO Authentication takes precedence over MFA when both are active. 
 
 The sub-commands can only be run at **layer** level and will not run anywhere else in the project.
-The sub-command `configure` can only be rut at an **EKS cluster layer** level. Usually called `cluster`.
+The sub-command `configure` can only be run at an **EKS cluster layer** level. Usually called `cluster`.
 
 The command can also be invoked via its shortened version `kc`.
 
@@ -48,5 +48,5 @@ Open a shell into the Kubectl container in the current directory.
 leverage kubectl configure
 ```
 
-Automatically add the cluster from the EKS layer into your kubectl config file.
+Add the cluster from the EKS layer into your kubectl config file.
 Equivalent to `aws eks update-kubeconfig ...`.

--- a/docs/user-guide/leverage-cli/reference/kubectl.md
+++ b/docs/user-guide/leverage-cli/reference/kubectl.md
@@ -1,13 +1,16 @@
 # Command: `kubectl`
 
 !!! info "Regarding Leverage Toolbox versions"
-    For using this feature Leverage Toolbox versions `<define>` and up, or `<define>` and up must be used.
+    For using this feature Leverage Toolbox versions `1.2.7-0.1.7` and up, or `1.3.5-0.1.7` and up must be used.
 
 The `kubectl` command is a wrapper for a containerized installation of [kubectl](https://kubernetes.io/docs/reference/kubectl/). It provides the kubectl executable with specific configuration values required by Leverage.
 
 It transparently handles authentication, whether it is Multi-Factor or via Single Sign-On, on behalf of the user in the commands that require it. SSO Authentication takes precedence over MFA when both are active. 
 
-This command can only be run at **layer** level and will not run anywhere else in the project.
+The sub-commands can only be run at **layer** level and will not run anywhere else in the project.
+The sub-command `configure` can only be rut at an **EKS cluster layer** level. Usually called `cluster`.
+
+The command can also be invoked via its shortened version `kc`.
 
 ---
 ## `run`
@@ -26,3 +29,24 @@ All arguments given are passed as received to kubectl.
 ```bash
 leverage kubectl get pods --namespace monitoring
 ```
+
+---
+## `shell`
+
+### Usage
+``` bash
+leverage kubectl shell
+```
+
+Open a shell into the Kubectl container in the current directory.
+
+---
+## `configure`
+
+### Usage
+``` bash
+leverage kubectl configure
+```
+
+Automatically add the cluster from the EKS layer into your kubectl config file.
+Equivalent to `aws eks update-kubeconfig ...`.

--- a/docs/user-guide/leverage-cli/reference/kubectl.md
+++ b/docs/user-guide/leverage-cli/reference/kubectl.md
@@ -1,0 +1,28 @@
+# Command: `kubectl`
+
+!!! info "Regarding Leverage Toolbox versions"
+    For using this feature Leverage Toolbox versions `<define>` and up, or `<define>` and up must be used.
+
+The `kubectl` command is a wrapper for a containerized installation of [kubectl](https://kubernetes.io/docs/reference/kubectl/). It provides the kubectl executable with specific configuration values required by Leverage.
+
+It transparently handles authentication, whether it is Multi-Factor or via Single Sign-On, on behalf of the user in the commands that require it. SSO Authentication takes precedence over MFA when both are active. 
+
+This command can only be run at **layer** level and will not run anywhere else in the project.
+
+---
+## `run`
+
+### Usage
+``` bash
+leverage kubectl [commands] [arguments]
+```
+
+Equivalent to `kubectl`.
+
+All arguments given are passed as received to kubectl. 
+
+**Example:**
+
+```bash
+leverage kubectl get pods --namespace monitoring
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -270,6 +270,7 @@ nav:
               - layers: "user-guide/leverage-cli/reference/terraform/layers.md"
           - tfautomv: "user-guide/leverage-cli/reference/tfautomv.md"
           - run: "user-guide/leverage-cli/reference/run.md"
+          - kubectl: "user-guide/leverage-cli/reference/kubectl.md"
       - Extending Leverage:
         - Overview: "user-guide/leverage-cli/extending-leverage/index.md"
         - build.env : "user-guide/leverage-cli/extending-leverage/build.env.md"


### PR DESCRIPTION
## What?
Adding the documentation for the new `kubectl` wrapper command.

## References
New required toolbox image: https://github.com/binbashar/le-docker-leverage-toolbox/pull/43
Feature: https://github.com/binbashar/leverage/pull/172


