### PR TITLE
ISSUE-173 added documentation on ssh-agent usage

### DIFF
--- a/docs/first-steps/post-deployment.md
+++ b/docs/first-steps/post-deployment.md
@@ -75,6 +75,9 @@ leverage credentials configure --type MANAGEMENT # or `SECURITY` depending on th
 !!! note
     Both of these credentials (management and security) require an MFA device to be enabled. Once either credential is configured, the next step ([Enable MFA](#enable-mfa)) becomes mandatory. If MFA is not enabled, any action on the project will be executed using the bootstrap credentials.
 
+!!! note
+    If a layer was already set with BOOTSTRAP credentials, when changing the credential type Terraform has to be reconfigured: `leverage tf init -reconfigure`.
+
 ## Enable MFA
 
 The last step is to enable Multi Factor Authentication locally. The procedure is slightly different for a `management` IAM user and `security` IAM user, so we'll walk through both of them.
@@ -169,6 +172,9 @@ leverage credentials configure --fetch-mfa-device --type SECURITY
 <span class="fsg-timestamp">[10:11:08.229]</span> INFO             Configuring profile <b>me-shared-oaar</b>
 <span class="fsg-timestamp">[10:11:23.185]</span> INFO     <b>Account profiles configured in:</b> <span class="fsg-path">/home/user/.aws/me/config</span>
 </code></pre>
+
+!!! note
+    If a layer was already set with BOOTSTRAP credentials, when changing the credential type Terraform has to be reconfigured: `leverage tf init -reconfigure`.
 
 ## Next steps
 

--- a/docs/user-guide/leverage-cli/reference/private-repos.md
+++ b/docs/user-guide/leverage-cli/reference/private-repos.md
@@ -1,6 +1,17 @@
-# Working with modules in private repos
+# Working with Terraform modules in private repos
 
 If it is the case that the layer is using a module from a private repository read the following.
+
+E.g.:
+
+```yaml
+module "themodule" {
+  source = "git@gitlab.com:some-org/some-project/the-private-repo.git//modules/the-module?ref=v0.0.1"
+  ...
+}
+```
+where `gitlab.com:some-org/some-project/the-private-repo.git` is a private repo.
+
 
 ## SSH accessed repository
 

--- a/docs/user-guide/leverage-cli/reference/private-repos.md
+++ b/docs/user-guide/leverage-cli/reference/private-repos.md
@@ -1,0 +1,26 @@
+# Working with modules in private repos
+
+If it is the case that the layer is using a module from a private repository read the following.
+
+## SSH accessed repository
+
+For using an SSH accessed private repository as a module for the layer these considerations have to be kept in mind.
+
+Leverage CLI will mount the host's SSH-Agent socket into the Levarage Toolbox container, this way your keys are accessed in a secure way.
+
+So, if an SSH private repo has to be reached the keys for such repo should be loaded in the SSH-Agent.
+
+If the agent is automatically started and the needed keys added in the host system, it should work as it is.
+
+In other case these steps should be followed:
+
+- start the SSH-Agent:
+```shell
+$ eval "$(ssh-agent -s)"
+```
+
+- add the keys to it
+```shell
+$ ssh-add ~/.ssh/id_ed25519
+```
+(add here the right file, the process can request the passphrase if it was set on key creation step)

--- a/docs/user-guide/leverage-cli/reference/private-repos.md
+++ b/docs/user-guide/leverage-cli/reference/private-repos.md
@@ -32,6 +32,6 @@ $ eval "$(ssh-agent -s)"
 
 - add the keys to it
 ```shell
-$ ssh-add ~/.ssh/id_ed25519
+$ ssh-add ~/.ssh/<private_ssh_key_file>
 ```
-(add here the right file, the process can request the passphrase if it was set on key creation step)
+(replace `private_ssh_key_file` with the desired file, the process can request the passphrase if it was set on key creation step)

--- a/docs/user-guide/leverage-cli/reference/private-repos.md
+++ b/docs/user-guide/leverage-cli/reference/private-repos.md
@@ -12,7 +12,7 @@ So, if an SSH private repo has to be reached the keys for such repo should be lo
 
 If the agent is automatically started and the needed keys added in the host system, it should work as it is.
 
-In other case these steps should be followed:
+These steps should be followed otherwise:
 
 - start the SSH-Agent:
 ```shell

--- a/docs/user-guide/leverage-cli/reference/private-repos.md
+++ b/docs/user-guide/leverage-cli/reference/private-repos.md
@@ -4,7 +4,7 @@ If it is the case that the layer is using a module from a private repository rea
 
 ## SSH accessed repository
 
-For using an SSH accessed private repository as a module for the layer these considerations have to be kept in mind.
+To source a Terraform module from a private repository in a layer via an SSH connection these considerations have to be kept in mind.
 
 Leverage CLI will mount the host's SSH-Agent socket into the Levarage Toolbox container, this way your keys are accessed in a secure way.
 

--- a/docs/user-guide/leverage-cli/reference/private-repos.md
+++ b/docs/user-guide/leverage-cli/reference/private-repos.md
@@ -17,7 +17,7 @@ where `gitlab.com:some-org/some-project/the-private-repo.git` is a private repo.
 
 To source a Terraform module from a private repository in a layer via an SSH connection these considerations have to be kept in mind.
 
-Leverage CLI will mount the host's SSH-Agent socket into the Levarage Toolbox container, this way your keys are accessed in a secure way.
+Leverage CLI will mount the host's SSH-Agent socket into the Leverage Toolbox container, this way your keys are accessed in a secure way.
 
 So, if an SSH private repo has to be reached, the keys for such repo should be loaded in the SSH-Agent.
 

--- a/docs/user-guide/leverage-cli/reference/private-repos.md
+++ b/docs/user-guide/leverage-cli/reference/private-repos.md
@@ -8,7 +8,7 @@ To source a Terraform module from a private repository in a layer via an SSH con
 
 Leverage CLI will mount the host's SSH-Agent socket into the Levarage Toolbox container, this way your keys are accessed in a secure way.
 
-So, if an SSH private repo has to be reached the keys for such repo should be loaded in the SSH-Agent.
+So, if an SSH private repo has to be reached, the keys for such repo should be loaded in the SSH-Agent.
 
 If the agent is automatically started and the needed keys added in the host system, it should work as it is.
 

--- a/docs/user-guide/leverage-cli/shell.md
+++ b/docs/user-guide/leverage-cli/shell.md
@@ -4,7 +4,7 @@ When launching a Terraform shell, Leverage provides the user with a completely i
 
 The whole project is mounted on a directory named after the value for `project_long` in the global configuration file, or simply named `"project"` if this value is not defined. A project named `myexample`, would be mounted in `/myexample`.
 
-The user's `~/.ssh` directory and `.gitconfig` file are also mounted on `/root/.ssh` and `/etc/gitconfig` respectively for convenience. Also, the credentials files (`credentials` and `config`) found in the project AWS credentials directory (`~/.aws/myexample`), are mapped to the locations given by the environment variables `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` respectively within the container. 
+The `.gitconfig` user's file is also mounted on `/etc/gitconfig` for convenience, while (if `ssh-agent` is running), the socket stated in `SSH_AUTH_SOCK` is mounted on `/ssh-agent`. Also, the credentials files (`credentials` and `config`) found in the project AWS credentials directory (`~/.aws/myexample`), are mapped to the locations given by the environment variables `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` respectively within the container. 
 
 ## Authentication
 Determining which credentials are needed to operate on a layer, and retrieving those credentials, may prove cumbersome for many complex layer definitions. In addition to that, correctly configuring them can also become a tedious an error prone process. For that reason Leverage automates this process upon launching the shell if requested by the user via the [`shell` command options](./reference/terraform.md#shell).

--- a/docs/user-guide/leverage-cli/shell.md
+++ b/docs/user-guide/leverage-cli/shell.md
@@ -4,7 +4,7 @@ When launching a Terraform shell, Leverage provides the user with a completely i
 
 The whole project is mounted on a directory named after the value for `project_long` in the global configuration file, or simply named `"project"` if this value is not defined. A project named `myexample`, would be mounted in `/myexample`.
 
-The `.gitconfig` user's file is mounted on `/etc/gitconfig` for convenience. If `ssh-agent` is running in the host, the socket stated in `SSH_AUTH_SOCK` is mounted on `/ssh-agent`, allowing easy ssh authentication to remote repositories if necessary. Lastly, the credentials files (`credentials` and `config`) found in the project AWS credentials directory (`~/.aws/myexample`), are mapped to the locations given by the environment variables `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` respectively within the container. 
+The `.gitconfig` user's file is also mounted on `/etc/gitconfig` for convenience, while (if `ssh-agent` is running), the socket stated in `SSH_AUTH_SOCK` is mounted on `/ssh-agent`. Also, the credentials files (`credentials` and `config`) found in the project AWS credentials directory (`~/.aws/myexample`), are mapped to the locations given by the environment variables `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` respectively within the container. 
 
 ## Authentication
 Determining which credentials are needed to operate on a layer, and retrieving those credentials, may prove cumbersome for many complex layer definitions. In addition to that, correctly configuring them can also become a tedious an error prone process. For that reason Leverage automates this process upon launching the shell if requested by the user via the [`shell` command options](./reference/terraform.md#shell).

--- a/docs/user-guide/leverage-cli/shell.md
+++ b/docs/user-guide/leverage-cli/shell.md
@@ -4,7 +4,7 @@ When launching a Terraform shell, Leverage provides the user with a completely i
 
 The whole project is mounted on a directory named after the value for `project_long` in the global configuration file, or simply named `"project"` if this value is not defined. A project named `myexample`, would be mounted in `/myexample`.
 
-The `.gitconfig` user's file is also mounted on `/etc/gitconfig` for convenience, while (if `ssh-agent` is running), the socket stated in `SSH_AUTH_SOCK` is mounted on `/ssh-agent`. Also, the credentials files (`credentials` and `config`) found in the project AWS credentials directory (`~/.aws/myexample`), are mapped to the locations given by the environment variables `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` respectively within the container. 
+The `.gitconfig` user's file is mounted on `/etc/gitconfig` for convenience. If `ssh-agent` is running in the host, the socket stated in `SSH_AUTH_SOCK` is mounted on `/ssh-agent`, allowing easy ssh authentication to remote repositories if necessary. Lastly, the credentials files (`credentials` and `config`) found in the project AWS credentials directory (`~/.aws/myexample`), are mapped to the locations given by the environment variables `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` respectively within the container. 
 
 ## Authentication
 Determining which credentials are needed to operate on a layer, and retrieving those credentials, may prove cumbersome for many complex layer definitions. In addition to that, correctly configuring them can also become a tedious an error prone process. For that reason Leverage automates this process upon launching the shell if requested by the user via the [`shell` command options](./reference/terraform.md#shell).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -271,6 +271,7 @@ nav:
           - tfautomv: "user-guide/leverage-cli/reference/tfautomv.md"
           - run: "user-guide/leverage-cli/reference/run.md"
           - kubectl: "user-guide/leverage-cli/reference/kubectl.md"
+        - Private repos: "user-guide/leverage-cli/reference/private-repos.md"
       - Extending Leverage:
         - Overview: "user-guide/leverage-cli/extending-leverage/index.md"
         - build.env : "user-guide/leverage-cli/extending-leverage/build.env.md"


### PR DESCRIPTION
## What?
* Information regarding the `SSH-Agent` usage was added under `user-guide/leverage-cli/reference/private-repos/`.

## Why?
* To clarify how Leverage CLI works regarding the SSH accessed private repositories and help the users to provide the correct SSH keys in order to be able to clone them.

## References
* related to https://github.com/binbashar/leverage/issues/173
* related to https://github.com/binbashar/leverage/pull/174
