### PR TITLE
Fix the height of the logo as it was covering the 'First steps' link …

### DIFF
--- a/material/overrides/main-styles.html
+++ b/material/overrides/main-styles.html
@@ -687,7 +687,7 @@ Blue color variations
 
         .md-header__title .md-header__ellipsis .md-header__topic{
             background-image: url(../assets/images/logos/binbash-nav-icon.svg);
-            height: 70px;
+            height: 40px;
             width: 150px;
             background-repeat: no-repeat;
             margin-top: 10px;


### PR DESCRIPTION
…making it really hard to click

## What?
* The height of the logo was extending too far down, making the click zone of the "First steps" top bar menu item hard to spot.

## Why?
* Logo height was unnecessarily tall.

## References
* N/A

