### PR TITLE
kubectl configure clarification

### DIFF
--- a/docs/user-guide/leverage-cli/reference/kubectl.md
+++ b/docs/user-guide/leverage-cli/reference/kubectl.md
@@ -12,6 +12,9 @@ The sub-command `configure` can only be run at an **EKS cluster layer** level. U
 
 The command can also be invoked via its shortened version `kc`.
 
+To start using this command, you must first run `leverage kubectl configure` on a `cluster` layer,
+to set up the credentials on the proper config file.
+
 ---
 ## `run`
 


### PR DESCRIPTION
## What?
Clarify a key step required to use the `kubectl` command.

## Why?
To avoid confusion.

## References
https://github.com/binbashar/leverage/pull/183
