### PR TITLE
Remove the steps that provision the identities layer from…

### DIFF
--- a/docs/try-leverage/management-account.md
+++ b/docs/try-leverage/management-account.md
@@ -46,13 +46,6 @@ When prompted, answer `yes`. Now you can safely remove the `terraform.tfstate` a
     * [Terraform backend](https://www.terraform.io/docs/language/settings/backends/index.html)
     * [How to manage Terraform state](https://blog.gruntwork.io/how-to-manage-terraform-state-28f5697e68fa)
 
-### Identities layer
-The definition for the identities layer is located within the `global` directory. Move into the `global/base-identities` directory and run:
-``` bash
-leverage terraform init
-leverage terraform apply
-```
-
 ### Organizations layer
 Next, in the same fashion as in the previous layer, move into the `global/organizations` directory and run:
 ``` bash

--- a/docs/try-leverage/security-and-shared-accounts.md
+++ b/docs/try-leverage/security-and-shared-accounts.md
@@ -40,13 +40,6 @@ When prompted, answer `yes`.
 
 Now you can safely remove the `terraform.tfstate` and `terraform.tfstate.backup` files created during the `apply` step.
 
-### Identities layer
-Now, move into the `global/base-identities` directory, and run:
-``` bash
-leverage terraform init
-leverage terraform apply
-```
-
 ### Security layer
 The last layer for the `security` account is the security layer. Move into the `us-east-1/security-base` directory and run:
 ``` bash
@@ -87,12 +80,6 @@ leverage terraform init
 When prompted, answer `yes`.
 
 Now you can safely remove the `terraform.tfstate` and `terraform.tfstate.backup` files created during the `apply` step.
-
-### Identities layer
-Now move into the `global/base-identities` directory and run:
-``` bash
-leverage terraform init
-```
 
 ### Security layer
 Next, move into the `us-east-1/security-base` directory:


### PR DESCRIPTION
…the Try Leverage section

## What?
* Remove the steps that provision the identities layer from the Try Leverage section.

## Why?
* We are favoring the SSO approach over the old IAM approach which the identities layers use.

## References
* https://github.com/binbashar/le-tf-infra-aws-template/issues/34

