### PR TITLE
Doc | updating domain from binbash.com.ar to binbash.co

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-leverage.binbash.com.ar
+leverage.binbash.co

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -4,5 +4,5 @@ binbash follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/bl
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
 the binbash Code of Conduct responsibles via:
-- <leverage@binbash.com.ar>
-- <info@binbash.com.ar>
+- <leverage@binbash.co>
+- <info@binbash.co>

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
-MAKEFILES_VER := v0.2.14
+MAKEFILES_VER := v0.2.16
 
 help:
 	@echo 'Available Commands:'

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 ## Overview
 This repository contains all files used to create 
-[binbash Leverage Reference Documentation](https://leverage.binbash.com.ar)
+[binbash Leverage Reference Documentation](https://leverage.binbash.co)
 
 ### Branches
 - `master`   --> contains the source code
 - `gh-pages` --> deployable (builded) version
 
 ## Deployed Documentation
-Check it out [here](https://leverage.binbash.com.ar/).
+Check it out [here](https://leverage.binbash.co/).
 
 ## Development / Contributing
 
@@ -28,7 +28,7 @@ Check it out [here](https://leverage.binbash.com.ar/).
 4. Update necessary `*.md` files inside the `docs/` folder and check your updates through the local environment
 browser 
 5. And create your PR from `BBL-XXX` to `master` branch.
-6. The Github Pages site [https://leverage.binbash.com.ar](https://leverage.binbash.com.ar/) will be automatically deployed 
+6. The Github Pages site [https://leverage.binbash.co](https://leverage.binbash.co/) will be automatically deployed 
 via CircleCI job to the `gh-pages` branch (currently being built from this branch).
     - It currently uses the `make docs-deploy-gh` cmd which could be locally executed if needed too.
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-leverage.binbash.com.ar
+leverage.binbash.co

--- a/docs/try-leverage/add-aws-accounts.md
+++ b/docs/try-leverage/add-aws-accounts.md
@@ -20,7 +20,7 @@ You can add new AWS accounts to your Leverage project by following the steps in 
         }
     ```
     Note that the `apps` organizational unit (OU) is being used as the parent OU of the new account. If you need to use a new OU you can add it to `organizational_units` variable in the same file.
-3. Run the [Terraform workflow](https://leverage.binbash.com.ar/user-guide/ref-architecture-aws/workflow/) to apply the new changes. Typically that would be this:
+3. Run the [Terraform workflow](https://leverage.binbash.co/user-guide/ref-architecture-aws/workflow/) to apply the new changes. Typically that would be this:
     ```shell
     leverage terraform init
     leverage terraform apply
@@ -101,7 +101,7 @@ In this example we will create the `apps-prd` account structure by using the `ap
             profile = "bb-apps-prd-oaar"
             ```
         2. In the step above, we are switching to the OAAR (OrganizationalAccountAccessRole) role because we are working with a brand new account that is empty, so, the only way to access it programmatically is through the OAAR role.
-        3. Now it's time to configure your OAAR credentials (if haven't already done so). For that you can follow the steps in [this section](https://leverage.binbash.com.ar/try-leverage/management-account/#update-the-bootstrap-credentials) of the official documentation.
+        3. Now it's time to configure your OAAR credentials (if haven't already done so). For that you can follow the steps in [this section](https://leverage.binbash.co/try-leverage/management-account/#update-the-bootstrap-credentials) of the official documentation.
 
 ### Create the Terraform Backend layer
 1. Copy the layer from an existing one:
@@ -118,7 +118,7 @@ In this example we will create the `apps-prd` account structure by using the `ap
     #    key = "apps-devstg/tf-backend/terraform.tfstate"
     #}
     ```
-3. Now run the [Terraform workflow](https://leverage.binbash.com.ar/user-guide/ref-architecture-aws/workflow/) to initialize and
+3. Now run the [Terraform workflow](https://leverage.binbash.co/user-guide/ref-architecture-aws/workflow/) to initialize and
     apply this layer. The flag `--skip-validation` is needed here since the bucket does not yet exist.
     ```shell
     leverage terraform init --skip-validation

--- a/docs/user-guide/ref-architecture-aws/features/identities/credentials-vault.md
+++ b/docs/user-guide/ref-architecture-aws/features/identities/credentials-vault.md
@@ -8,7 +8,7 @@ installation. We always favours a private endpoint deployment only accessible
 from the VPN.
 
 ### AWS Self Hosted Vault Instance Endpoint
-`vault_address = "https://vault.aws.binbash.com.ar:8200"`
+`vault_address = "https://vault.aws.binbash.co:8200"`
 
 ### HCP Vault private API endpoint
 `vault_address = "https://bb-le-shared-vault-cluster.private.vault.xxxxxxxxxx.aws.hashicorp.cloud:8200"`

--- a/docs/work-with-us/archived/contact.md.back
+++ b/docs/work-with-us/archived/contact.md.back
@@ -2,11 +2,11 @@
 
 !!! info "Contact points"
 
-    * [x] 📧 **Email |** [info@binbash.com.ar](https://mail.google.com/mail/?view=cm&fs=1&to=info@binbash.com.ar&su=Leverage Contact&body=Dear Leverage Team,)
-    * [x] 🌎 **Web Site |** [https://www.binbash.com.ar](https://www.binbash.com.ar)
+    * [x] 📧 **Email |** [info@binbash.co](https://mail.google.com/mail/?view=cm&fs=1&to=info@binbash.co&su=Leverage Contact&body=Dear Leverage Team,)
+    * [x] 🌎 **Web Site |** [https://www.binbash.co](https://www.binbash.co)
     * [x] 🏢 **LinkedIn |** [https://www.linkedin.com/company/binbash](https://www.linkedin.com/company/binbash)
     * [x] 📞 **Phone |** +1 786 2244551
     * [x] 📱 ** WhatsApp / Telegram |** +54 9351 5510132 || +54 93543 516289
     * [x] 💬 ** Slack |** [Join Leverage channel](https://join.slack.com/t/binbashar/shared_invite/zt-fw1692b6-9k4ADsWJ47lKacszphXM1w) 
 
-[Contact Us :fontawesome-solid-paper-plane:](https://www.binbash.com.ar/contact){ .md-button .md-button--primary }
+[Contact Us :fontawesome-solid-paper-plane:](https://www.binbash.co/contact){ .md-button .md-button--primary }

--- a/docs/work-with-us/careers.md
+++ b/docs/work-with-us/careers.md
@@ -50,7 +50,7 @@
         
         Improve, maintain, extend and update our reference architecture, which has been designed under optimal configs 
         for the most popular modern web and mobile applications needs. Its design is fully based on the 
-        [**AWS Well Architected Framework**](https://leverage.binbash.com.ar/support/#aws-well-architected-review).
+        [**AWS Well Architected Framework**](https://leverage.binbash.co/support/#aws-well-architected-review).
     
     - [x] **Open Source & Leverage DevOps Tools** 
         
@@ -61,7 +61,7 @@
     
     - [x] **Document team knowledge**
      
-        Get siloed and not yet documented knowledge and extend the [Leverage documentation](https://leverage.binbash.com.ar), such as 
+        Get siloed and not yet documented knowledge and extend the [Leverage documentation](https://leverage.binbash.co), such as 
         creating knowledgebase articles, runbooks, and other documentation for the internal team as well as binbash
         Leverage customers.
 

--- a/docs/work-with-us/faqs.md
+++ b/docs/work-with-us/faqs.md
@@ -70,14 +70,14 @@
 !!! question ":credit_card: Rates and pricing plans"
     
     - [x] **Pre-paid package subscriptions:** A number of prepaid hours is agreed according to the needs 
-    of the project. It could be a [**"Basic Plan"**](https://leverage.binbash.com.ar/work-with-us/subscription-plans/)
-    of 40 hours per month. Or a [**"Premium Plan"**](https://leverage.binbash.com.ar/work-with-us/subscription-plans/)
+    of the project. It could be a [**"Basic Plan"**](https://leverage.binbash.co/work-with-us/subscription-plans/)
+    of 40 hours per month. Or a [**"Premium Plan"**](https://leverage.binbash.co/work-with-us/subscription-plans/)
     of 80 hours per month (if more hours are needed it could be reviewed). When buying in 
     bulk there is a discount on the value of the hour. When you pay for the package you start discounting
     the hours from the total as they are used, and if there are unused hours left, consider that maximum 20% 
     could be transferred for the next month.
 
-    - [x] [**On-demand Business Subscription**](https://leverage.binbash.com.ar/work-with-us/subscription-plans/): There are
+    - [x] [**On-demand Business Subscription**](https://leverage.binbash.co/work-with-us/subscription-plans/): There are
     a certain number of hours tracked each month, as planned tasks are demanded. The total spent hours will be reported 
     each month. There is a monthly minimum of 40 hours per month. Support tasks maximum estimated effort should
     be between 80 and 120 hs / month.

--- a/docs/work-with-us/releases/versions-compatibility-matrix.md
+++ b/docs/work-with-us/releases/versions-compatibility-matrix.md
@@ -50,7 +50,7 @@ We suggest they should be upgraded soon.
 
 This project does not follow the **Terraform** or other release schedule. Leverage aims to
 provide a reliable deployment and operations experience for the [binbash Leverage™ Reference Architecture
-for AWS](https://leverage.binbash.com.ar/how-it-works/ref-architecture/), and typically releases about a quarter after
+for AWS](https://leverage.binbash.co/how-it-works/ref-architecture/), and typically releases about a quarter after
 the corresponding Terraform release. This time allows for the Terraform project to resolve any issues introduced
 by the new version and ensures that we can support the latest features.
 

--- a/docs/work-with-us/support.md
+++ b/docs/work-with-us/support.md
@@ -3,7 +3,7 @@
 ## Leverage Reference Architecture
 
 Please create a [Github Issue](https://github.com/binbashar/le-tf-infra-aws/issues/new/choose) to
-get immediate support from the [binbash Leverage Team](https://www.binbash.com.ar)
+get immediate support from the [binbash Leverage Team](https://www.binbash.co)
 
 ### Our Engineering & Support Team
 

--- a/material/overrides/home-es.html
+++ b/material/overrides/home-es.html
@@ -22,7 +22,7 @@
         <button
           type="button"
           title="{{ page.next_page.title | e }}"
-          onclick="location.href='https://leverage.binbash.com.ar/concepts/overview/'"
+          onclick="location.href='https://leverage.binbash.co/concepts/overview/'"
           class="btn-dark btn-xl-large btn-lg-large mx-3  mt-3 my-md-5 my-lg-5 my-xl-5 box-shadow"
         >
             Empezar
@@ -121,7 +121,7 @@
             Sobre un código que está completamente documentado, validado y que ha sido probado en producción en docenas de otros proyectos por nuestro <span class="t-b">Equipo de soporte de ingeniería.</span>
           </p>
           <button
-            onclick="location.href='https://www.binbash.com.ar/leverage'"
+            onclick="location.href='https://www.binbash.co/leverage'"
             title="{{ page.next_page.title | e }}"
             type="button"
             class="btn-dark btn-xl-large btn-lg-large my-4 box-shadow ml-auto mx-xs-auto mx-sm-auto mx-md-auto"
@@ -160,7 +160,7 @@
         </div>
         <div class="conteiner ctx-card-white-1 text-white h3 my-5 mx-auto w-70">
           <btn
-            onclick="window.open('https://leverage.binbash.com.ar/work-with-us/leverage-vs-competition/','_blank')"
+            onclick="window.open('https://leverage.binbash.co/work-with-us/leverage-vs-competition/','_blank')"
             title="{{ lang.t('source.link.title') }}"
             type="button"
             class="btn-rainbow btn-rainbow-custom btn-xl-large btn-lg-large mx-auto text-align-center cursor-pointer"
@@ -210,7 +210,7 @@
       </div>
       <div style="order:0; flex: 50%;">
         <button
-          onclick="location.href='https://leverage.binbash.com.ar/how-it-works/ref-architecture/general-concepts/why-tech-stack'"
+          onclick="location.href='https://leverage.binbash.co/how-it-works/ref-architecture/general-concepts/why-tech-stack'"
           title="{{ page.next_page.title | e }}"
           type="button"
           class="btn-dark btn-xl-large btn-lg-large my-4 box-shadow mx-auto"
@@ -239,19 +239,19 @@
         <div class="conteiner text-white h3">
           <ul>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/" target="_blank">Inicio</a>
+              <a href="https://www.binbash.co/" target="_blank">Inicio</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/" target="_blank">Soluciones</a>
+              <a href="https://www.binbash.co/" target="_blank">Soluciones</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/leverage" target="_blank">Leverage</a>
+              <a href="https://www.binbash.co/leverage" target="_blank">Leverage</a>
             </li>
             <li class="cursor-pointer item-text-footer">
               <a href="https://medium.com/binbash-inc" target="_blank">Blog</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/contact" target="_blank">Contacto</a>
+              <a href="https://www.binbash.co/contact" target="_blank">Contacto</a>
             </li>
           </ul>
         </div>
@@ -263,16 +263,16 @@
               <a href="https://github.com/sponsors/binbashar" target="_blank">Sobre nosotros</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/team" target="_blank">Equipo</a>
+              <a href="https://www.binbash.co/team" target="_blank">Equipo</a>
             </li>
             <li class="cursor-pointer item-text-footer">
               <a href="https://github.com/binbashar" target="_blank">Recursos</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/" target="_blank">Testimonios</a>
+              <a href="https://www.binbash.co/" target="_blank">Testimonios</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/pricing" target="_blank">Precios</a>
+              <a href="https://www.binbash.co/pricing" target="_blank">Precios</a>
             </li>
           </ul>
         </div>

--- a/material/overrides/home.html
+++ b/material/overrides/home.html
@@ -122,7 +122,7 @@
             On top of code that is thoroughly documented, tested, and has been proven in production at dozens of other project deployments <span class="t-b">our Engineering Support Team.</span>
           </p>
           <button
-            onclick="location.href='https://www.binbash.com.ar/leverage'"
+            onclick="location.href='https://www.binbash.co/leverage'"
             title="{{ page.next_page.title | e }}"
             type="button"
             class="btn-dark btn-xl-large btn-lg-large my-4 box-shadow ml-auto mx-xs-auto mx-sm-auto mx-md-auto"
@@ -161,7 +161,7 @@
         </div>
         <div class="conteiner ctx-card-white-1 text-white h3 my-5 mx-auto w-70">
           <btn
-            onclick="window.open('https://leverage.binbash.com.ar/work-with-us/leverage-vs-competition/','_blank')"
+            onclick="window.open('https://leverage.binbash.co/work-with-us/leverage-vs-competition/','_blank')"
             title="{{ lang.t('source.link.title') }}"
             type="button"
             class="btn-rainbow btn-rainbow-custom btn-xl-large btn-lg-large mx-auto text-align-center cursor-pointer"
@@ -240,19 +240,19 @@
         <div class="conteiner text-white h3">
           <ul>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/" target="_blank">Home</a>
+              <a href="https://www.binbash.co/" target="_blank">Home</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/" target="_blank">Solutions</a>
+              <a href="https://www.binbash.co/" target="_blank">Solutions</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/leverage" target="_blank">Leverage</a>
+              <a href="https://www.binbash.co/leverage" target="_blank">Leverage</a>
             </li>
             <li class="cursor-pointer item-text-footer">
               <a href="https://medium.com/binbash-inc" target="_blank">Blog</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/contact" target="_blank">Contact</a>
+              <a href="https://www.binbash.co/contact" target="_blank">Contact</a>
             </li>
           </ul>
         </div>
@@ -264,16 +264,16 @@
               <a href="https://github.com/sponsors/binbashar" target="_blank">About Us</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/team" target="_blank">Team</a>
+              <a href="https://www.binbash.co/team" target="_blank">Team</a>
             </li>
             <li class="cursor-pointer item-text-footer">
               <a href="https://github.com/binbashar" target="_blank">Resources</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/" target="_blank">Testimonials</a>
+              <a href="https://www.binbash.co/" target="_blank">Testimonials</a>
             </li>
             <li class="cursor-pointer item-text-footer">
-              <a href="https://www.binbash.com.ar/pricing" target="_blank">Pricing</a>
+              <a href="https://www.binbash.co/pricing" target="_blank">Pricing</a>
             </li>
           </ul>
         </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,10 +5,10 @@
 site_name: binbash Leverage™
 repo_name: "binbashar/le-ref-architecture-doc"
 repo_url: https://github.com/binbashar/le-ref-architecture-doc
-site_url: https://leverage.binbash.com.ar/
+site_url: https://leverage.binbash.co/
 site_description: binbash Leverage Reference Architecture Documentation
 site_author: binbash
-copyright: Copyright &copy; 2017-2023 <a href="https://www.binbash.com.ar">binbash</a>
+copyright: Copyright &copy; 2017-2023 <a href="https://www.binbash.co">binbash</a>
 
 #===================================================================================#
 # Mkdocs Theme (Material Mkdocs) + Extras
@@ -76,7 +76,7 @@ extra:
 
   social:
     - icon: material/home
-      link: 'https://www.binbash.com.ar'
+      link: 'https://www.binbash.co'
     - icon: material/github
       link: 'https://github.com/binbashar'
     - icon: material/linkedin
@@ -95,13 +95,13 @@ extra:
   alternate:
     # Switch to English
     - name: English
-      #link: https://leverage.binbash.com.ar
+      #link: https://leverage.binbash.co
       link: /
       lang: en
 
     # Switch to Spanish
     - name: Spanish
-      #link: https://leverage.binbash.com.ar/es/
+      #link: https://leverage.binbash.co/es/
       link: /es
       lang: es
 
@@ -304,4 +304,4 @@ nav:
       #- Team: "work-with-us/team.md"
       #- Testimonials: "work-with-us/testimonials.md"
       - FAQs: "work-with-us/faqs.md"
-      - Contact Us: https://www.binbash.com.ar/contact
+      - Contact Us: https://www.binbash.co/contact


### PR DESCRIPTION
## What?

### Commits on Jun 24, 2023
- [updating domain from binbash.com.ar to binbash.co](https://github.com/binbashar/le-ref-architecture-doc/commit/d0b223a1cd764627daa44dfb5f6d96471fe3e569) - @[exequielrafaela](https://github.com/binbashar/le-ref-architecture-doc/commits?author=exequielrafaela)

## Why?
* [LEWW-130 | Configure binbash.co](https://trello.com/c/Zve2yEql/130-leww-130-configure-binbashco)
* Sitemap.xml generation for proper google analytics and search console integrations

