### PR TITLE
Create index page for credentials under AWS and EKS reference architectures

### DIFF
--- a/docs/user-guide/ref-architecture-aws/configuration.md
+++ b/docs/user-guide/ref-architecture-aws/configuration.md
@@ -23,8 +23,6 @@
 ## Setting credentials for Terraform via AWS profiles
 - File `backend.tfvars` will inject the profile name that TF will use to make changes on AWS.
 - Such profile is usually one that relies on another profile to assume a role to get access to each corresponding account.
-- Please follow to correctly setup your AWS Credentials
-    - [user-guide/user-guide/identities](/user-guide/identities/identities.md)
-    - [user-guide/user-guide/identities/credentials](/user-guide/identities/credentials.md) 
+- Please read [the credentials section](./credentials.md) to understand the alternatives supported by Leverage to authenticate with AWS.
 - Read the following page leverage doc to understand [how to set up a profile to assume 
 a role](https://docs.aws.amazon.com/cli/latest/userguide/cli-roles.html)

--- a/docs/user-guide/ref-architecture-aws/credentials.md
+++ b/docs/user-guide/ref-architecture-aws/credentials.md
@@ -1,0 +1,12 @@
+# Credentials
+
+## Overview
+Currently the following two methods are supported:
+
+1. [x] **AWS IAM:** this is essentially using on-disk, permanent programmatic credentials that are tied to a given IAM User. This method can optionally support MFA which is highly recommended since using permanent credentials is discouraged, so at least with MFA you can counter-balance that. [Keep reading...](./features/sso/configuration.md)
+2. [x] **AWS IAM Identity Center (formerly known as AWS SSO):** this one is more recent and it's the method recommeded by AWS since it uses roles (managed by AWS) which in turn enforce the usage of temporary credentials. [Keep reading...](./features/identities/identities.md)
+
+## Next Steps
+If you are planning to choose SSO (highly recommended), check out [this section](./features/sso/overview.md).
+
+If you are instead interested in using IAM + MFA, refer to [this other section](./features/identities/overview.md) instead.

--- a/docs/user-guide/ref-architecture-eks/credentials.md
+++ b/docs/user-guide/ref-architecture-eks/credentials.md
@@ -1,0 +1,9 @@
+# Credentials
+
+## Overview
+Access to EKS is usually achieved via IAM roles. These could be either custom IAM roles that you define, or SSO roles that AWS takes care of creating and managing.
+
+## Configuration
+Granting different kinds of access to IAM roles can be done as shown [here](https://github.com/binbashar/le-tf-infra-aws/blob/master/apps-devstg/us-east-1/k8s-eks/cluster/locals.tf#L33-L60) where you can define classic IAM roles or SSO roles. Note however that, since the latter are managed by AWS SSO, they could change if they are recreated or reassigned.
+
+Now, even though granting access to roles is the preferred way, keep in mind that that is not the only way you can use. You can also grant access [to specific users](https://github.com/binbashar/le-tf-infra-aws/blob/master/apps-devstg/us-east-1/k8s-eks/cluster/locals.tf#L18-L29) or [to specific accounts](https://github.com/binbashar/le-tf-infra-aws/blob/master/apps-devstg/us-east-1/k8s-eks/cluster/locals.tf#L10-L14).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -183,6 +183,7 @@ nav:
       - Overview: "user-guide/ref-architecture-aws/overview.md"
       - Project Structure: "user-guide/ref-architecture-aws/dir-structure.md"
       - Configuration: "user-guide/ref-architecture-aws/configuration.md"
+      - Credentials: "user-guide/ref-architecture-aws/credentials.md"
       - Workflow: "user-guide/ref-architecture-aws/workflow.md"
       - Terraform State: "user-guide/ref-architecture-aws/tf-state.md"
       - Features:
@@ -252,6 +253,7 @@ nav:
       - References: "user-guide/ref-architecture-aws/references.md"
     - Reference Architecture for EKS:
       - Overview: "user-guide/ref-architecture-eks/overview.md"
+      - Credentials: "user-guide/ref-architecture-eks/credentials.md"
       - VPC: "user-guide/ref-architecture-eks/vpc.md"
       - Components: "user-guide/ref-architecture-eks/components.md"
       - Upgrading EKS: "user-guide/ref-architecture-eks/cluster-upgrade.md"


### PR DESCRIPTION
## What?
* Create index page for credentials under AWS and EKS reference architectures
* Also briefly update AWS configuration page to link to the new pages

## Why?
* Since we support multiple ways to handle credentials, having an entry page makes sense.

## References
* Issue: #122 
