### PR TITLE
FIX quick fix to a command line example

### DIFF
--- a/docs/user-guide/cookbooks/argocd-external-cluster.md
+++ b/docs/user-guide/cookbooks/argocd-external-cluster.md
@@ -481,7 +481,7 @@ To recover the token and the API Server run this:
 
 ```shell
 NAMESPACE=test
-SECRET=$(leverage kubectl get secret -n ${NAMESPACE} -o jsonpath='{.items[?(@.metadata.generateName==\"argocd-managed-\")].metadata.name}' | sed -E '/^\[/d')
+SECRET=$(leverage kubectl get secret -n ${NAMESPACE} -o jsonpath='{.items[?(@.metadata.generateName=="argocd-managed-")].metadata.name}' | sed -E '/^\[/d')
 TOKEN=$(leverage kubectl get secret ${SECRET} -n ${NAMESPACE} -o jsonpath='{.data.token}' | sed -E '/^\[/d' | base64 --decode)
 APISERVER=$(leverage kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed -E '/^\[/d')
 ```


### PR DESCRIPTION
## What?
* quick fix to a command line example

## Why?
* it was pasted with escaped chars when no escape is needed
![image](https://github.com/binbashar/le-ref-architecture-doc/assets/2184738/a2c0237a-5a38-4eac-a0f6-d1f543b186cc)
(removing backslashes previous to quotes)
