### PR TITLE
Added documentation on how to troubleshoot the case of scaping chars in CLI

### DIFF
--- a/docs/user-guide/leverage-cli/reference/terraform.md
+++ b/docs/user-guide/leverage-cli/reference/terraform.md
@@ -58,6 +58,17 @@ Can only be run at **layer** level if `--layers` is not set, or at **account** o
 ### Options
 * `--layers`: Applies command to layers listed in this option. (see more info [here](./layers))
 
+!!! info "using indexes"
+    When using `-target` flag with resources using indexes, it is possible you need to escape chars like this:
+
+    **Example:**
+
+    - For target:  `aws_route53_record.main["*.binbash.com.ar"]`
+    - Use:  `leverage tf plan -target='aws_route53_record.main[\"*.binbash.com.ar\"]'`
+    
+    Note the single and double quotes. 
+    This is valid for ZSH and BASH.
+
 ---
 ## `apply`
 
@@ -75,6 +86,11 @@ Can only be run at **layer** level if `--layers` is not set, or at **account** o
 ### Options
 * `--layers`: Applies command to layers listed in this option. (see more info [here](./layers))
 
+!!! info "using indexes"
+    When using `-target` flag with resources using indexes, it is possible you need to escape chars.
+
+    See notes for `plan` [here](#plan).
+    
 ---
 ## `destroy`
 
@@ -91,6 +107,12 @@ Can only be run at **layer** level if `--layers` is not set, or at **account** o
 
 ### Options
 * `--layers`: Applies command to layers listed in this option. (see more info [here](./layers))
+
+!!! info "using indexes"
+    When using `-target` flag with resources using indexes, it is possible you need to escape chars.
+
+    See notes for `plan` [here](#plan).
+    
 
 ---
 ## `output`

--- a/docs/user-guide/troubleshooting/general.md
+++ b/docs/user-guide/troubleshooting/general.md
@@ -102,3 +102,20 @@ In order to fix this, just configure git globally:
 $ git config --global user.name "Name Lastname"
 $ git config --global user.email "name.lastname@email.com"
 ```
+## Leverage CLI targeting specific resources with indexes
+
+Sometimes you want to target a specific resource, eg. when importing:
+
+```shell
+leverage terraform import aws_organizations_account.management 999999999999
+```
+
+But the real issue comes when indexes have to be used.
+
+To do this escape the target string like this:
+
+```shell
+leverage tf import 'aws_organizations_account.accounts[\"accountalias\"]' 99999999999
+```
+
+The same applies to other commands such as `plan`.

--- a/docs/user-guide/troubleshooting/general.md
+++ b/docs/user-guide/troubleshooting/general.md
@@ -118,4 +118,16 @@ To do this escape the target string like this:
 leverage tf import 'aws_organizations_account.accounts[\"accountalias\"]' 99999999999
 ```
 
-The same applies to other commands such as `plan`.
+For more info on escaping indexes for `import` see [here](../../leverage-cli/reference/terraform/#import)
+
+The same applies to other commands such as `plan`, `destroy` or `apply` when using `-target` with indexes.
+
+E.g.:
+
+```shell
+leverage tf plan -target='aws_route53_record.main[\"*.binbash.com.ar\"]'
+```
+
+Note the use of single quotes and double quotes.
+
+For more info on escaping indexes for `plan`, `destroy` and `apply` see [here](../../leverage-cli/reference/terraform/#plan)


### PR DESCRIPTION
## What?
* Added documentation on how to escape chars using the command line for resource arrays.

## Why?
* It is not a common case, but it worth to be documented.

## References
N/A

## Important
Please include a screenshot of the pages that you modified to help reviewers. If you are using Chrome, you can follow the instructions below to easily take a full screenshot of the entire page:
1. Right click the page and open the inspector.
2. In the top left of Chrome Inspector you'll see a little phone icon whose tooltip shows "Toggle device emulation".
3. Hit that and a new black bar will appear on the top of the webpage.
4. In the black bar you can pick the dimensions of the screen you want to stimulate -- Since the documentation uses a responsive layout, you'll probably want to set a wide enough value on the width field, e.g. 1024x768, then the height is not as important.
5. In top right of black bar is three dots, in that menu you can do a full page screenshot.

![image](https://github.com/user-attachments/assets/5a82b4f3-611d-4bf6-ad01-ed67254d5c7f)
