### PR TITLE
Fixed VPN link in cookbooks

### DIFF
--- a/docs/user-guide/cookbooks/index.md
+++ b/docs/user-guide/cookbooks/index.md
@@ -7,5 +7,5 @@
 - [x] [Encrypting/decrypting files with SOPS+KMS](./sops-kms.md)
 - [x] [Enable/Disable nat gateway](./enable-nat-gateway.md)
 - [x] [ArgoCD add external cluster](./argocd-external-cluster.md)
-- [x] [VPN Server](./VPN-server.md)
+- [x] [VPN Server](./VPN-server)
 


### PR DESCRIPTION
## What?
* Fixed link in Cookbooks

## Why?
* It is failing

## References
N/A

## Important
Please include a screenshot of the pages that you modified to help reviewers. If you are using Chrome, you can follow the instructions below to easily take a full screenshot of the entire page:
1. Right click the page and open the inspector.
2. In the top left of Chrome Inspector you'll see a little phone icon whose tooltip shows "Toggle device emulation".
3. Hit that and a new black bar will appear on the top of the webpage.
4. In the black bar you can pick the dimensions of the screen you want to stimulate -- Since the documentation uses a responsive layout, you'll probably want to set a wide enough value on the width field, e.g. 1024x768, then the height is not as important.
5. In top right of black bar is three dots, in that menu you can do a full page screenshot.
