### PR TITLE
Doc | Update custom tasks flags documentation

### DIFF
--- a/docs/user-guide/leverage-cli/basic-features.md
+++ b/docs/user-guide/leverage-cli/basic-features.md
@@ -8,12 +8,9 @@ Usage: leverage [OPTIONS] COMMAND [ARGS]...
   Leverage Reference Architecture projects command-line tool.
 
 Options:
-  -f, --filename TEXT  Name of the build file containing the tasks
-                       definitions.  [default: build.py]
-  -l, --list-tasks     List available tasks to run.
-  -v, --verbose        Increase output verbosity.
-  --version            Show the version and exit.
-  --help               Show this message and exit.
+  -v, --verbose  Increase output verbosity.
+  --version      Show the version and exit.
+  --help         Show this message and exit.
 
 Commands:
   aws          Run AWS CLI commands in a custom containerized environment.
@@ -31,50 +28,37 @@ Commands:
 Similarly, subcommands provide further information by means of the `--help` flag. For example `leverage tf --help`.
 
 ## Global options
-* `-f` | `--filename`:  Name of the file containing the tasks' definition. Defaults to `build.py`
-* `-l` | `--list-tasks`: List all the tasks defined for the project along a description of their purpose (when available).  
-  ```
-  Tasks in build file `build.py`:
-
-    clean                  	Clean build directory.
-    copy_file              	
-    echo                   	
-    html                   	Generate HTML.
-    images        [Ignored]	Prepare images.
-    start_server  [Default]	Start the server
-    stop_server            	
-
-  Powered by Leverage 1.9.0
-  ```
 * `-v` | `--verbose`: Increases output verbosity.  
   When running a command in a container, the tool provides a description of the container's configuration before the execution.  
   This is specially useful if the user were to to have the need of recreating Leverage's behavior by themselves.  
   ``` bash
   $ leverage -v tf plan
-  [18:23:22.222] DEBUG    Found config file /home/user/binbash/le-tf-infra-aws/build.env
-  [18:23:22.239] DEBUG    Container configuration:
+  [20:27:44.758] DEBUG    Found config file /home/user/binbash/le-tf-infra-aws/build.env
+  [20:27:44.812] DEBUG    Container configuration:
                           {
-                            "image": "binbash/leverage-toolbox:1.2.7-0.1.7", #(1)!
+                            "image": "binbash/leverage-toolbox:1.5.0-0.2.3-1000-1000", #(1)!
                             "command": "",
                             "stdin_open": true,
                             "environment": { #(2)!
                               "COMMON_CONFIG_FILE": "/binbash/config/common.tfvars",
-                              "ACCOUNT_CONFIG_FILE": "/binbash/security/config/account.tfvars",
-                              "BACKEND_CONFIG_FILE": "/binbash/security/config/backend.tfvars",
-                              "AWS_SHARED_CREDENTIALS_FILE": "/root/tmp/bb/credentials",
-                              "AWS_CONFIG_FILE": "/root/tmp/bb/config",
-                              "SRC_AWS_SHARED_CREDENTIALS_FILE": "/root/tmp/bb/credentials",
-                              "SRC_AWS_CONFIG_FILE": "/root/tmp/bb/config",
-                              "AWS_CACHE_DIR": "/root/tmp/bb/cache",
-                              "SSO_CACHE_DIR": "/root/tmp/bb/sso/cache",
+                              "ACCOUNT_CONFIG_FILE": "/binbash/apps-devstg/config/account.tfvars",
+                              "BACKEND_CONFIG_FILE": "/binbash/apps-devstg/config/backend.tfvars",
+                              "AWS_SHARED_CREDENTIALS_FILE": "/home/leverage/tmp/bb/credentials",
+                              "AWS_CONFIG_FILE": "/home/leverage/tmp/bb/config",
+                              "SRC_AWS_SHARED_CREDENTIALS_FILE": "/home/leverage/tmp/bb/credentials",
+                              "SRC_AWS_CONFIG_FILE": "/home/leverage/tmp/bb/config",
+                              "AWS_CACHE_DIR": "/home/leverage/tmp/bb/cache",
+                              "SSO_CACHE_DIR": "/home/leverage/tmp/bb/sso/cache",
+                              "SCRIPT_LOG_LEVEL": 3,
+                              "MFA_SCRIPT_LOG_LEVEL": 3,
                               "SSH_AUTH_SOCK": "/ssh-agent"
                             },
                             "entrypoint": "/bin/terraform",
-                            "working_dir": "/binbash/security/global/base-identities",
+                            "working_dir": "/binbash/apps-devstg/us-east-1/k8s-eks/identities",
                             "host_config": {
                               "NetworkMode": "default",
                               "SecurityOpt": [
-                                "label:disable"
+                                "label=disable"
                               ],
                               "Mounts": [ #(3)!
                                 {
@@ -84,7 +68,7 @@ Similarly, subcommands provide further information by means of the `--help` flag
                                   "ReadOnly": false
                                 },
                                 {
-                                  "Target": "/root/tmp/bb",
+                                  "Target": "/home/leverage/tmp/bb",
                                   "Source": "/home/user/.aws/bb",
                                   "Type": "bind",
                                   "ReadOnly": false
@@ -104,11 +88,25 @@ Similarly, subcommands provide further information by means of the `--help` flag
                               ]
                             }
                           }
-  [18:23:22.274] DEBUG    Checking for layer /home/user/binbash/le-tf-infra-aws/security/global/base-identities...
-  [18:23:22.279] DEBUG    Checking layer /home/user/binbash/le-tf-infra-aws/security/global/base-identities...
-  [18:23:22.282] DEBUG    Running command: sh -c 'cat $SSO_CACHE_DIR/token'
-  [18:23:22.901] DEBUG    Running with entrypoint: /root/scripts/aws-sso/aws-sso-entrypoint.sh -- /bin/terraform
-  [18:23:22.903] DEBUG    Running command: plan -var-file=/binbash/config/common.tfvars -var-file=/binbash/security/config/account.tfvars -var-file=/binbash/security/config/backend.tfvars #(4)!
+  [20:27:44.825] INFO     Checking for local docker image, tag: 1.5.0-0.2.3-1000-1000...
+  [20:27:44.851] INFO     ✔ OK
+
+  [20:27:44.853] DEBUG    Checking for layer /home/user/binbash/le-tf-infra-aws/apps-devstg/us-east-1/k8s-eks/identities...
+  [20:27:44.875] DEBUG    Checking layer /home/user/binbash/le-tf-infra-aws/apps-devstg/us-east-1/k8s-eks/identities...
+  [20:27:44.876] DEBUG    Running command: sh -c 'cat $SSO_CACHE_DIR/token'
+  [20:27:47.469] INFO     Attempting to get temporary credentials for shared account.
+  [20:27:47.471] DEBUG    Token expiration time: 1740094585.0
+                DEBUG    Token renewal time: 1740182267.470991
+  [20:27:47.472] DEBUG    Retrieving role credentials for DevOps...
+  [20:27:48.558] INFO     Writing binbash-shared-devops profile
+  [20:27:48.564] INFO     Credentials for shared account written successfully.
+  [20:27:48.567] INFO     Attempting to get temporary credentials for apps-devstg account.
+  [20:27:48.570] DEBUG    Token expiration time: 1740094584.0
+  [20:27:48.571] DEBUG    Token renewal time: 1740182268.5704691
+  [20:27:48.572] DEBUG    Retrieving role credentials for DevOps...
+  [20:27:49.171] INFO     Writing binbash-apps-devstg-devops profile
+  [20:27:49.177] INFO     Credentials for apps-devstg account written successfully.
+  [20:27:49.182] DEBUG    Running command: plan -var-file=/binbash/config/common.tfvars -var-file=/binbash/apps-devstg/config/account.tfvars -var-file=/binbash/apps-devstg/config/backend.tfvars #(4)!
   ...
   ```  
 

--- a/docs/user-guide/leverage-cli/installation.md
+++ b/docs/user-guide/leverage-cli/installation.md
@@ -3,7 +3,7 @@
 To use Leverage CLI you need to install it from the Python Package Index (Pypi). Currently, only Linux and Mac OS are supported operative systems.
 
 !!! done "Requirements"
-    * [x] **Python** `>= 3.8`
+    * [x] **Python** `>= 3.9`
     * [x] **Git** `>= 2.25`
     * [x] **Docker engine** `>= 20.x.y`
 
@@ -65,19 +65,18 @@ Usage: leverage [OPTIONS] COMMAND [ARGS]...
   Leverage Reference Architecture projects command-line tool.
 
 Options:
-  -f, --filename TEXT  Name of the build file containing the tasks
-                       definitions.  [default: build.py]
-  -l, --list-tasks     List available tasks to run.
-  -v, --verbose        Increase output verbosity.
-  --version            Show the version and exit.
-  --help               Show this message and exit.
+  -v, --verbose  Increase output verbosity.
+  --version      Show the version and exit.
+  --help         Show this message and exit.
 
 Commands:
   aws          Run AWS CLI commands in a custom containerized environment.
   credentials  Manage AWS cli credentials.
+  kc           Run Kubectl commands in a custom containerized environment.
   kubectl      Run Kubectl commands in a custom containerized environment.
   project      Manage a Leverage project.
   run          Perform specified task(s) and all of its dependencies.
+  shell        Run a shell in a generic container.
   terraform    Run Terraform commands in a custom containerized...
   tf           Run Terraform commands in a custom containerized...
   tfautomv     Run TFAutomv commands in a custom containerized...

--- a/docs/user-guide/leverage-cli/reference/run.md
+++ b/docs/user-guide/leverage-cli/reference/run.md
@@ -23,3 +23,20 @@ leverage run task1 task2[arg1,arg2] task3[arg1,kwarg1=val1,kwarg2=val2]
 * `task2` receives two positional arguments `arg1` and `arg2`
   
 * `task3` receives one positional argument `arg1` and two keyworded arguments `kwarg1` with value `val1` and `kwarg2` with value `val2`
+
+### Options
+* `-f` | `--filename`:  Name of the file containing the tasks' definition. Defaults to `build.py`
+* `-l` | `--list-tasks`: List all the tasks defined for the project along a description of their purpose (when available).  
+  ```
+  Tasks in build file `build.py`:
+
+    clean                  	Clean build directory.
+    copy_file              	
+    echo                   	
+    html                   	Generate HTML.
+    images        [Ignored]	Prepare images.
+    start_server  [Default]	Start the server
+    stop_server            	
+
+  Powered by Leverage 1.13.0
+  ```


### PR DESCRIPTION
## What?
* Move custom tasks flags documentation from basic usage page to the run command page.
* Update documentation for verbose output to reflect current state.
