### PR TITLE
Fix VPN guide link

### DIFF
--- a/docs/user-guide/ref-architecture-aws/features/security/vpn.md
+++ b/docs/user-guide/ref-architecture-aws/features/security/vpn.md
@@ -24,7 +24,7 @@ Pritunl documentation v1 Guides, accessed November 17th 2020).
 </figcaption>
 
 !!! info "Tip"
-    To deploy your Pritunl VPN Server you can follow [this guide](../../../cookbooks/VPN-server.md)
+    To deploy your Pritunl VPN Server you can follow [this guide](../../../cookbooks/VPN-server/index.md)
 
 ### Read More
 - [x] [Pritunl - Open Source Enterprise Distributed OpenVPN, IPsec and WireGuard Server Specifications](https://drive.google.com/file/d/1piF0pZSTwcV4oHTIh_VsqZzEWTK5_zlv/view?usp=sharing) :cloud: :lock:


### PR DESCRIPTION
## Summary
- fix broken Pritunl VPN guide link by using relative path

## Testing
- `make help`


------
https://chatgpt.com/codex/tasks/task_e_687a88a9ec14832f8a71e6fe7f2d528c